### PR TITLE
Fix classloader for Spring Boot devtools, re quartz#221

### DIFF
--- a/src/main/resources/quartz.properties
+++ b/src/main/resources/quartz.properties
@@ -8,3 +8,8 @@ org.quartz.jobStore.tablePrefix=QRTZ_
 
 org.quartz.jobStore.isClustered=true
 org.quartz.jobStore.clusterCheckinInterval=20000
+
+# A different classloader is needed to work with Spring Boot dev mode,
+# see https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html#using-boot-devtools-known-restart-limitations
+# and https://github.com/quartz-scheduler/quartz/issues/221
+org.quartz.scheduler.classLoadHelper.class=org.quartz.simpl.ThreadContextClassLoadHelper


### PR DESCRIPTION
I have found that Spring Boot devtools switches the context classloader, but Quartz does not respect that.

This config change is needed to prevent Spring loading two different Classes for any Job classes, which interferes with Autowiring (as the two Class objects from different classloaders do not compare as equal).

I have raised  https://github.com/quartz-scheduler/quartz/issues/221 to try to get this fixed upstream